### PR TITLE
Fix PHP warnings

### DIFF
--- a/includes/Models/PriorityQueue.php
+++ b/includes/Models/PriorityQueue.php
@@ -7,20 +7,6 @@ namespace NewfoldLabs\WP\Module\Installer\Models;
 class PriorityQueue extends \SplPriorityQueue {
 
 	/**
-	 * Defines the logic to use when comparing two priorities.
-	 *
-	 * @param mixed $priority1 First Priority Queue
-	 * @param mixed $priority2 Second Priority Queue
-	 * @return int
-	 */
-	public function compare( $priority1, $priority2 ) : int {
-		if ( $priority1 === $priority2 ) {
-			return 0;
-		}
-		return $priority1 < $priority2 ? -1 : 1;
-	}
-
-	/**
 	 * Converts the max heap to an array.
 	 *
 	 * @return array

--- a/includes/Services/PluginInstaller.php
+++ b/includes/Services/PluginInstaller.php
@@ -309,11 +309,11 @@ class PluginInstaller {
 	 *
 	 * @param string $plugin The slug of the plugin.
 	 * @param string $plugin_type The type of plugin.
-	 * @return string
+	 * @return string|false
 	 */
 	public static function get_plugin_path( $plugin, $plugin_type ) {
 		$plugin_list = Plugins::get();
-		return $plugin_list[ $plugin_type ][ $plugin ]['path'];
+		return isset( $plugin_list[ $plugin_type ][ $plugin ] ) ? $plugin_list[ $plugin_type ][ $plugin ]['path'] : false;
 	}
 
 	/**
@@ -326,7 +326,7 @@ class PluginInstaller {
 	public static function exists( $plugin, $activate ) {
 		$plugin_type = self::get_plugin_type( $plugin );
 		$plugin_path = self::get_plugin_path( $plugin, $plugin_type );
-		if ( ! self::is_plugin_installed( $plugin_path ) ) {
+		if ( ! ( $plugin_path && self::is_plugin_installed( $plugin_path ) ) ) {
 			return false;
 		}
 
@@ -355,7 +355,7 @@ class PluginInstaller {
 	public static function activate( $plugin ) {
 		$plugin_type = self::get_plugin_type( $plugin );
 		$plugin_path = self::get_plugin_path( $plugin, $plugin_type );
-		if ( ! self::is_plugin_installed( $plugin_path ) ) {
+		if ( ! ( $plugin_path && self::is_plugin_installed( $plugin_path ) ) ) {
 			return false;
 		}
 
@@ -376,7 +376,7 @@ class PluginInstaller {
 	public static function deactivate( $plugin ) {
 		$plugin_type = self::get_plugin_type( $plugin );
 		$plugin_path = self::get_plugin_path( $plugin, $plugin_type );
-		if ( ! self::is_plugin_installed( $plugin_path ) ) {
+		if ( ! ( $plugin_path && self::is_plugin_installed( $plugin_path ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
Fixes
```
[19-Mar-2024 07:42:28 UTC] PHP Warning:  Undefined array key "yith-product-search-extended" in /Users/arun.sh/Desktop/WordPress/repos/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-installer/includes/Services/PluginInstaller.php on line 316
[19-Mar-2024 07:42:28 UTC] PHP Warning:  Trying to access array offset on value of type null in /Users/arun.sh/Desktop/WordPress/repos/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-installer/includes/Services/PluginInstaller.php on line 316
```
And
```
Deprecated: Return type of
NewfoldLabs|WP|Module\Installer\Models\PriorityQueue::compare($priority1, $priority2) should
either be compatible with SplPriorityQueue::compare (mixed $priority1, mixed $priority2): int, or
the #[ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in
/app/wordpress/content/plugins/bluehost-wordpress-plugin/vendor/newfold-labs/wp-module-
installer/includes/Models/PriorityQueue.php on line 16
```
