### PR TITLE
Add Support for Premium Plugin Activations

### DIFF
--- a/includes/RestApi/PluginsController.php
+++ b/includes/RestApi/PluginsController.php
@@ -127,14 +127,18 @@ class PluginsController {
 				'type'    => 'boolean',
 				'default' => false,
 			),
+			'provider' => array(
+				'type'    => 'string',
+				'default' => '',
+			),
 		);
 	}
 
-			/**
-			 * Get args for the uninstall route.
-			 *
-			 * @return array
-			 */
+	/**
+	 * Get args for the uninstall route.
+	 *
+	 * @return array
+	 */
 	public function get_uninstall_plugin_args() {
 		return array(
 			'plugin'   => array(
@@ -183,10 +187,11 @@ class PluginsController {
 		$queue    = $request->get_param( 'queue' );
 		$priority = $request->get_param( 'priority' );
 		$premium  = $request->get_param( 'premium' );
+		$provider = $request->get_param( 'provider' );
 
 		// Checks if the plugin is premium and uses the corresponding function for it.
 		if ( true === $premium ) {
-			return PluginInstaller::install_premium_plugin( $plugin, $activate );
+			return PluginInstaller::install_premium_plugin( $plugin, $provider, $activate );
 		}
 
 		// Checks if a plugin with the given slug and activation criteria already exists.

--- a/includes/Services/PluginInstaller.php
+++ b/includes/Services/PluginInstaller.php
@@ -161,21 +161,8 @@ class PluginInstaller {
 	 * @return \WP_Error|\WP_REST_Response
 	 */
 	public static function install_premium_plugin( $plugin, $activate ) {
-		$status_codes = Plugins::get_status_codes();
-
-		$premium_status = self::get_plugin_status( $plugin );
-
-		// Check if the premium plugin is already installed or active
-		if ( $status_codes['active'] === $premium_status || $status_codes['installed'] === $premium_status ) {
-			return new \WP_REST_Response(
-				array(
-					'message' => __( 'Premium plugin already installed or active: ', 'wp-module-installer' ) . $plugin,
-				),
-				200
-			);
-		}
-
 		$pls_utility = new PLSUtility();
+
 		// Provision a license for the premium plugin
 		$license_response = $pls_utility->provision_license( $plugin );
 		if ( is_wp_error( $license_response ) ) {

--- a/includes/Services/PluginInstaller.php
+++ b/includes/Services/PluginInstaller.php
@@ -175,9 +175,7 @@ class PluginInstaller {
 			);
 		}
 
-		// Create an instance of PLSUtility for handling license operations
 		$pls_utility = new PLSUtility();
-
 		// Provision a license for the premium plugin
 		$license_response = $pls_utility->provision_license( $plugin );
 		if ( is_wp_error( $license_response ) ) {
@@ -205,7 +203,7 @@ class PluginInstaller {
 
 		return new \WP_REST_Response(
 			array(
-				'message' => __( 'Successfully provisioned, installed, and activated: ', 'wp-module-installer' ) . $plugin,
+				'message' => __( 'Successfully provisioned: ', 'wp-module-installer' ) . $plugin,
 			),
 			200
 		);

--- a/includes/Services/PluginInstaller.php
+++ b/includes/Services/PluginInstaller.php
@@ -205,8 +205,6 @@ class PluginInstaller {
 		);
 	}
 
-
-
 	/**
 	 * Install the plugin from a custom ZIP.
 	 *

--- a/includes/Services/PluginInstaller.php
+++ b/includes/Services/PluginInstaller.php
@@ -156,15 +156,24 @@ class PluginInstaller {
 	 * Provisions a license and installs or activates a premium plugin.
 	 *
 	 * @param string  $plugin The slug of the premium plugin.
+	 * @param string  $provider The provider name for the premium plugin.
 	 * @param boolean $activate Whether to activate the plugin after installation.
 	 *
 	 * @return \WP_Error|\WP_REST_Response
 	 */
-	public static function install_premium_plugin( $plugin, $activate ) {
+	public static function install_premium_plugin( $plugin, $provider, $activate ) {
+		// Ensure plugin and provider are not empty
+		if ( empty( $plugin ) || empty( $provider ) ) {
+			return new \WP_Error(
+				'nfd_installer_error',
+				__( 'Plugin slug and provider name cannot be empty.', 'wp-module-installer' )
+			);
+		}
+
 		$pls_utility = new PLSUtility();
 
 		// Provision a license for the premium plugin
-		$license_response = $pls_utility->provision_license( $plugin );
+		$license_response = $pls_utility->provision_license( $plugin, $provider );
 		if ( is_wp_error( $license_response ) ) {
 			return $license_response;
 		}
@@ -195,6 +204,7 @@ class PluginInstaller {
 			200
 		);
 	}
+
 
 
 	/**

--- a/includes/WPAdmin/Listeners/InstallerListener.php
+++ b/includes/WPAdmin/Listeners/InstallerListener.php
@@ -64,7 +64,7 @@ class InstallerListener {
 	}
 
 	/**
-	 * Listens for premium plugin activation.
+	 * Listens for premium plugin activation using activated_plugin hook.
 	 *
 	 * @return void
 	 */
@@ -78,17 +78,19 @@ class InstallerListener {
 			return;
 		}
 
-		// Loop through each plugin in the license data and hook to its activation using basename
-		foreach ( $license_data_store as $plugin_slug => $license_data ) {
-			if ( isset( $license_data['basename'] ) ) {
-				$basename = $license_data['basename'];
-				add_action(
-					'activate_' . $basename,
-					function () use ( $plugin_slug, $pls_utility ) {
+		// Hook into activated_plugin action to trigger license activation after plugin activation
+		add_action(
+			'activated_plugin',
+			function ( $plugin, $network_wide ) use ( $pls_utility, $license_data_store ) {
+				foreach ( $license_data_store as $plugin_slug => $license_data ) {
+					if ( isset( $license_data['basename'] ) && $license_data['basename'] === $plugin ) {
 						$pls_utility->activate_license( $plugin_slug );
+						break;
 					}
-				);
-			}
-		}
+				}
+			},
+			10,
+			2
+		);
 	}
 }

--- a/includes/WPAdmin/Listeners/InstallerListener.php
+++ b/includes/WPAdmin/Listeners/InstallerListener.php
@@ -3,6 +3,7 @@
 namespace NewfoldLabs\WP\Module\Installer\WPAdmin\Listeners;
 
 use NewfoldLabs\WP\Module\Installer\Services\PluginInstaller;
+use NewfoldLabs\WP\Module\PLS\Utilities\PLSUtility;
 
 /**
  * Manages all the installer enqueue related functionalities for the module.
@@ -13,7 +14,11 @@ class InstallerListener {
 	 * Constructor for the Installer class.
 	 */
 	public function __construct() {
+		// Hook to enqueue installer scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_installer_script' ) );
+
+		// Hook to listen to premium plugin activation
+		$this->listen_for_premium_plugin_activation();
 	}
 
 	/**
@@ -25,7 +30,6 @@ class InstallerListener {
 		$asset_file = NFD_INSTALLER_BUILD_DIR . '/installer.asset.php';
 
 		if ( is_readable( $asset_file ) ) {
-
 			$asset = include $asset_file;
 
 			wp_register_script(
@@ -56,6 +60,39 @@ class InstallerListener {
 
 			wp_enqueue_script( 'nfd-installer-enqueue' );
 			wp_enqueue_style( 'nfd-installer-enqueue' );
+		}
+	}
+
+	/**
+	 * Listens for premium plugin activation.
+	 *
+	 * @return void
+	 */
+	private function listen_for_premium_plugin_activation() {
+		$pls_utility = new PLSUtility();
+
+		// Retrieve the license data (decrypted) from the option
+		$license_data_store = $pls_utility->retrieve_license_data();
+
+		if ( ! $license_data_store || empty( $license_data_store ) ) {
+			return;
+		}
+
+		// Loop through each plugin in the license data and hook to its activation using basename
+		foreach ( $license_data_store as $plugin_slug => $license_data ) {
+			// Ensure that the basename is present in the license data
+			if ( isset( $license_data['basename'] ) ) {
+				$basename = $license_data['basename'];
+
+				// Hook into plugin activation using the basename
+				add_action(
+					'activate_' . $basename,
+					function () use ( $plugin_slug, $pls_utility ) {
+						// Call the activate_license function when this plugin is activated
+						$pls_utility->activate_license( $plugin_slug );
+					}
+				);
+			}
 		}
 	}
 }

--- a/includes/WPAdmin/Listeners/InstallerListener.php
+++ b/includes/WPAdmin/Listeners/InstallerListener.php
@@ -80,15 +80,11 @@ class InstallerListener {
 
 		// Loop through each plugin in the license data and hook to its activation using basename
 		foreach ( $license_data_store as $plugin_slug => $license_data ) {
-			// Ensure that the basename is present in the license data
 			if ( isset( $license_data['basename'] ) ) {
 				$basename = $license_data['basename'];
-
-				// Hook into plugin activation using the basename
 				add_action(
 					'activate_' . $basename,
 					function () use ( $plugin_slug, $pls_utility ) {
-						// Call the activate_license function when this plugin is activated
 						$pls_utility->activate_license( $plugin_slug );
 					}
 				);

--- a/includes/WPAdmin/Listeners/InstallerListener.php
+++ b/includes/WPAdmin/Listeners/InstallerListener.php
@@ -72,7 +72,7 @@ class InstallerListener {
 		$pls_utility = new PLSUtility();
 
 		// Retrieve the license data (decrypted) from the option
-		$license_data_store = $pls_utility->retrieve_license_data();
+		$license_data_store = $pls_utility->retrieve_license_storage_map();
 
 		if ( ! $license_data_store || empty( $license_data_store ) ) {
 			return;

--- a/includes/WPCLI/Handlers/InstallerCommandHandler.php
+++ b/includes/WPCLI/Handlers/InstallerCommandHandler.php
@@ -86,21 +86,24 @@ class InstallerCommandHandler {
 	/**
 	 * Triggers the installation and activation of a premium plugin.
 	 *
-	 * This command provisions a license, installs the premium plugin, and optionally activates it based on the
-	 * activation parameter passed. It outputs the status of the process.
+	 * This command provisions a license, installs the premium plugin, and optionally activates it
+	 * based on the activation parameter passed. It outputs the status of the process.
 	 *
 	 * ## OPTIONS
 	 *
 	 * <premium_slug>
 	 * : The slug of the premium plugin to be installed.
 	 *
+	 * <provider>
+	 * : The name of the provider for the premium plugin.
+	 *
 	 * [--activate]
 	 * : Optional flag to activate the plugin after installation.
 	 *
 	 * ## EXAMPLES
 	 *
-	 *     wp installer install_premium_plugin <premium_slug> --activate
-	 *     wp installer install_premium_plugin <premium_slug>
+	 *     wp installer install_premium_plugin <premium_slug> <provider> --activate
+	 *     wp installer install_premium_plugin <premium_slug> <provider>
 	 *
 	 * @param array $args Arguments passed from the command line. First argument is the plugin slug.
 	 * @param array $assoc_args Associative arguments (like --activate).
@@ -109,10 +112,17 @@ class InstallerCommandHandler {
 	 */
 	public function install_premium_plugin( $args, $assoc_args ) {
 		$premium_slug = $args[0];
+		$provider     = $args[1];
 		$activate     = isset( $assoc_args['activate'] );
 
+		// Ensure both the plugin slug and provider are not empty
+		if ( empty( $premium_slug ) || empty( $provider ) ) {
+			WP_CLI::error( __( 'Both plugin slug and provider name are required.', 'wp-module-installer' ) );
+			return;
+		}
+
 		// Call the function to provision, install, and (optionally) activate the premium plugin
-		$status = PluginInstaller::install_premium_plugin( $premium_slug, $activate );
+		$status = PluginInstaller::install_premium_plugin( $premium_slug, $provider, $activate );
 
 		// Handle error or success response
 		if ( is_wp_error( $status ) ) {

--- a/src/Installer/components/App/index.jsx
+++ b/src/Installer/components/App/index.jsx
@@ -8,6 +8,7 @@ import { INSTALLER_DIV } from '../../constants';
 const App = () => {
 	const [ pluginName, setPluginName ] = useState();
 	const [ pluginSlug, setPluginSlug ] = useState();
+	const [ pluginProvider, setPluginProvider ] = useState();
 	const [ pluginURL, setPluginURL ] = useState();
 	const [ pluginActivate, setPluginActivate ] = useState();
 
@@ -29,6 +30,9 @@ const App = () => {
 		setPluginSlug(
 			element.getAttribute( 'nfd-installer-app__plugin--slug' )
 		);
+		setPluginProvider(
+			element.getAttribute( 'nfd-installer-app__plugin--provider' )
+		);
 		setPluginURL(
 			element.getAttribute( 'nfd-installer-app__plugin--url' )
 		);
@@ -45,6 +49,7 @@ const App = () => {
 					pluginSlug={ pluginSlug }
 					pluginURL={ pluginURL }
 					pluginActivate={ pluginActivate }
+					pluginProvider={ pluginProvider }
 				/>
 			) }
 		</div>

--- a/src/Installer/components/Modal/index.jsx
+++ b/src/Installer/components/Modal/index.jsx
@@ -12,7 +12,13 @@ import {
 	pluginInstallHash,
 } from '../../constants';
 
-const Modal = ( { pluginName, pluginSlug, pluginURL, pluginActivate } ) => {
+const Modal = ( {
+	pluginName,
+	pluginSlug,
+	pluginURL,
+	pluginActivate,
+	pluginProvider,
+} ) => {
 	/**
 	 * Represents the status of the plugin installation process.
 	 *
@@ -74,6 +80,7 @@ const Modal = ( { pluginName, pluginSlug, pluginURL, pluginActivate } ) => {
 					priority: 0,
 					premium: true,
 					plugin: pluginSlug,
+					provider: pluginProvider,
 				},
 			} );
 			setPluginStatus( 'completed' );
@@ -120,11 +127,16 @@ const Modal = ( { pluginName, pluginSlug, pluginURL, pluginActivate } ) => {
 								icon={ info }
 							/>
 							{ sprintf(
+								// translators: %1$s and %2$s are HTML tags used to format the contact support link
 								__(
 									'Sorry, there was an error installing and activating the plugin. Please try again. If the problem persists, %1$scontact support%2$s.',
 									'wp-module-onboarding'
 								),
-								'<a href="' + window.NewfoldRuntime.adminUrl + 'admin.php?page=' + window.NewfoldRuntime.plugin.brand + '#/help">',
+								'<a href="' +
+									window.NewfoldRuntime.adminUrl +
+									'admin.php?page=' +
+									window.NewfoldRuntime.plugin.brand +
+									'#/help">',
 								'</a>'
 							) }
 						</div>

--- a/src/Scripts/dataAttrListener.js
+++ b/src/Scripts/dataAttrListener.js
@@ -5,15 +5,14 @@ import domReady from '@wordpress/dom-ready';
 import { INSTALLER_DIV } from '../Installer/constants';
 
 domReady( () => {
-	// function removeModal() {
-	// 	// find the modal and remove if it exists
-	// 	const modal = document.querySelector( '.nfd-installer' );
-	// 	if ( modal ) {
-	// 		modal.remove();
-	// 	}
-	// }
 
-	function renderModal( pluginName, pluginSlug, pluginURL, activate ) {
+	function renderModal(
+		pluginName,
+		pluginSlug,
+		pluginProvider,
+		pluginURL,
+		activate
+	) {
 		// create the installer div
 		document.getElementById( INSTALLER_DIV ).style.display = 'block';
 		document
@@ -22,6 +21,12 @@ domReady( () => {
 		document
 			.getElementById( INSTALLER_DIV )
 			.setAttribute( 'nfd-installer-app__plugin--slug', pluginSlug );
+		document
+			.getElementById( INSTALLER_DIV )
+			.setAttribute(
+				'nfd-installer-app__plugin--provider',
+				pluginProvider
+			);
 		document
 			.getElementById( INSTALLER_DIV )
 			.setAttribute( 'nfd-installer-app__plugin--url', pluginURL );
@@ -59,6 +64,9 @@ domReady( () => {
 											),
 											this.getAttribute(
 												'data-nfd-installer-plugin-slug'
+											),
+											this.getAttribute(
+												'data-nfd-installer-plugin-provider'
 											),
 											this.getAttribute(
 												'data-nfd-installer-plugin-url'


### PR DESCRIPTION
## Proposed changes

- Replaced static method calls with the instantiation of `PLSUtility` where required.
- Modified the `install_premium_plugin` method to handle license activation after the plugin is installed when the `activate` flag is true.
- Implemented a listener that listens for premium plugin activations and activates the license based on the premium plugin’s `basename`.

Ref: https://github.com/newfold-labs/wp-module-pls/pull/6

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
