### PR TITLE
Defensive checks in cron rescheduling

### DIFF
--- a/includes/TaskManagers/AbstractTaskManager.php
+++ b/includes/TaskManagers/AbstractTaskManager.php
@@ -1,0 +1,69 @@
+<?php
+namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
+
+use NewfoldLabs\WP\Module\Installer\Data\Options;
+
+/**
+ * Manages the execution of Tasks.
+ */
+abstract class AbstractTaskManager {
+
+	/**
+	 * The number of times a PluginUninstallTask can be retried.
+	 *
+	 * @var int
+	 */
+	protected  static $retry_limit = 1;
+
+	/**
+	 * Name of the Queue.
+	 *
+	 * @var string
+	 */
+	protected static $queue_name = '';
+
+	/**
+	 * Name of the Hook.
+	 *
+	 * @var string
+	 */
+	protected static $hook_name = '';
+
+	/**
+	 * PluginUninstallTaskManager constructor.
+	 */
+	public function __construct() {
+		TaskManagerSchedules::init();
+	}
+
+	/**
+	 * Retrieve the Queue Name for the TaskManager.
+	 *
+	 * @return string
+	 */
+	public static function get_queue_name() {
+		return static::$queue_name;
+	}
+
+
+	/**
+	 * Retrieve the Hook Name for the TaskManager.
+	 *
+	 * @return string
+	 */
+	public static function get_hook_name() {
+		return static::$hook_name;
+	}
+
+
+	/**
+	 * Returns the status of given plugin slug - uninstalling/completed.
+	 *
+	 * @param string $plugin Plugin Slug
+	 * @return string|false
+	 */
+	public static function status( $plugin ) {
+		$plugins = \get_option( Options::get_option_name( static::$queue_name ), array() );
+		return array_search( $plugin, array_column( $plugins, 'slug' ), true );
+	}
+}

--- a/includes/TaskManagers/AbstractTaskManager.php
+++ b/includes/TaskManagers/AbstractTaskManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 
 use NewfoldLabs\WP\Module\Installer\Data\Options;
@@ -13,7 +14,7 @@ abstract class AbstractTaskManager {
 	 *
 	 * @var int
 	 */
-	protected  static $retry_limit = 1;
+	protected static $retry_limit = 1;
 
 	/**
 	 * Name of the Queue.

--- a/includes/TaskManagers/PluginActivationTaskManager.php
+++ b/includes/TaskManagers/PluginActivationTaskManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 
 use NewfoldLabs\WP\Module\Installer\Data\Options;
@@ -8,43 +9,40 @@ use NewfoldLabs\WP\Module\Installer\Tasks\PluginActivationTask;
 /**
  * Manages the execution of PluginActivationTasks.
  */
-class PluginActivationTaskManager {
-
+class PluginActivationTaskManager extends AbstractTaskManager {
 	/**
-	 * The number of times a PluginActivationTask can be retried.
+	 * The number of times Hook can be retried.
 	 *
 	 * @var int
 	 */
-	private static $retry_limit = 1;
+	protected static $retry_limit = 1;
 
 	/**
 	 * The name of the queue, might be prefixed.
 	 *
 	 * @var string
 	 */
-	private static $queue_name = 'plugin_activation_queue';
+	protected static $queue_name = 'plugin_activation_queue';
+
+	/**
+	 * The name of the hook, might be prefixed.
+	 *
+	 * @var string
+	 */
+	protected static $hook_name = 'nfd_module_installer_plugin_activation_event';
 
 	/**
 	 * Schedules the crons.
 	 */
 	public function __construct() {
+		parent::__construct();
 
-		// Thirty second cron hook
-		add_action( 'nfd_module_installer_plugin_activation_event', array( $this, 'activate' ) );
+		// Thirty seconds cron hook
+		add_action( self::$hook_name, array( $this, 'activate' ) );
 
-		if ( ! wp_next_scheduled( 'nfd_module_installer_plugin_activation_event' ) ) {
-			wp_schedule_single_event( time() + 5, 'nfd_module_installer_plugin_activation_event' );
+		if ( ! wp_next_scheduled( self::$hook_name ) ) {
+			wp_schedule_single_event( time() + 5, self::$hook_name );
 		}
-	}
-
-
-	/**
-	 * Returns the queue name, might be prefixed.
-	 *
-	 * @return string
-	 */
-	public static function get_queue_name() {
-		return self::$queue_name;
 	}
 
 
@@ -64,9 +62,9 @@ class PluginActivationTaskManager {
 		$retries = array();
 		foreach ( $plugins as $plugin ) {
 			$plugin_activation_task = new PluginActivationTask(
-				$plugin['slug'],
-				$plugin['priority'],
-				$plugin['retries']
+				$plugin[ 'slug' ],
+				$plugin[ 'priority' ],
+				$plugin[ 'retries' ]
 			);
 			$status                 = $plugin_activation_task->execute();
 			if ( is_wp_error( $status ) ) {
@@ -103,10 +101,10 @@ class PluginActivationTaskManager {
 			Check if there is an already existing PluginActivationTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin['slug'] === $plugin_activation_task->get_slug() ) {
+			if ( $queued_plugin[ 'slug' ] === $plugin_activation_task->get_slug() ) {
 				return false;
 			}
-			$queue->insert( $queued_plugin, $queued_plugin['priority'] );
+			$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
 		}
 
 		// Insert a new PluginActivationTask at the appropriate position in the queue.
@@ -136,22 +134,11 @@ class PluginActivationTaskManager {
 			/*
 			If the Plugin slug does not match add it back to the queue.
 			*/
-			if ( $queued_plugin['slug'] !== $plugin ) {
-				$queue->insert( $queued_plugin, $queued_plugin['priority'] );
+			if ( $queued_plugin[ 'slug' ] !== $plugin ) {
+				$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
 			}
 		}
 
 		return \update_option( Options::get_option_name( self::$queue_name ), $queue->to_array() );
-	}
-
-	/**
-	 * Get the status of a given plugin slug from the queue.
-	 *
-	 * @param string $plugin The slug of the plugin.
-	 * @return boolean
-	 */
-	public static function status( $plugin ) {
-		$plugins = \get_option( Options::get_option_name( self::$queue_name ), array() );
-		return array_search( $plugin, array_column( $plugins, 'slug' ), true );
 	}
 }

--- a/includes/TaskManagers/PluginActivationTaskManager.php
+++ b/includes/TaskManagers/PluginActivationTaskManager.php
@@ -62,9 +62,9 @@ class PluginActivationTaskManager extends AbstractTaskManager {
 		$retries = array();
 		foreach ( $plugins as $plugin ) {
 			$plugin_activation_task = new PluginActivationTask(
-				$plugin[ 'slug' ],
-				$plugin[ 'priority' ],
-				$plugin[ 'retries' ]
+				$plugin['slug'],
+				$plugin['priority'],
+				$plugin['retries']
 			);
 			$status                 = $plugin_activation_task->execute();
 			if ( is_wp_error( $status ) ) {
@@ -101,10 +101,10 @@ class PluginActivationTaskManager extends AbstractTaskManager {
 			Check if there is an already existing PluginActivationTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin[ 'slug' ] === $plugin_activation_task->get_slug() ) {
+			if ( $queued_plugin['slug'] === $plugin_activation_task->get_slug() ) {
 				return false;
 			}
-			$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 		}
 
 		// Insert a new PluginActivationTask at the appropriate position in the queue.
@@ -134,8 +134,8 @@ class PluginActivationTaskManager extends AbstractTaskManager {
 			/*
 			If the Plugin slug does not match add it back to the queue.
 			*/
-			if ( $queued_plugin[ 'slug' ] !== $plugin ) {
-				$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			if ( $queued_plugin['slug'] !== $plugin ) {
+				$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 			}
 		}
 

--- a/includes/TaskManagers/PluginDeactivationTaskManager.php
+++ b/includes/TaskManagers/PluginDeactivationTaskManager.php
@@ -56,9 +56,9 @@ class PluginDeactivationTaskManager extends AbstractTaskManager {
 		$retries = array();
 		foreach ( $plugins as $plugin ) {
 			$plugin_deactivation_task = new PluginDeactivationTask(
-				$plugin[ 'slug' ],
-				$plugin[ 'priority' ],
-				$plugin[ 'retries' ]
+				$plugin['slug'],
+				$plugin['priority'],
+				$plugin['retries']
 			);
 			$status                   = $plugin_deactivation_task->execute();
 			if ( ! $status ) {
@@ -95,10 +95,10 @@ class PluginDeactivationTaskManager extends AbstractTaskManager {
 			Check if there is an already existing PluginDeactivationTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin[ 'slug' ] === $plugin_deactivation_task->get_slug() ) {
+			if ( $queued_plugin['slug'] === $plugin_deactivation_task->get_slug() ) {
 				return false;
 			}
-			$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 		}
 
 		// Insert a new PluginDeactivationTask at the appropriate position in the queue.
@@ -128,8 +128,8 @@ class PluginDeactivationTaskManager extends AbstractTaskManager {
 			/*
 			If the Plugin slug does not match add it back to the queue.
 			*/
-			if ( $queued_plugin[ 'slug' ] !== $plugin ) {
-				$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			if ( $queued_plugin['slug'] !== $plugin ) {
+				$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 			}
 		}
 

--- a/includes/TaskManagers/PluginInstallTaskManager.php
+++ b/includes/TaskManagers/PluginInstallTaskManager.php
@@ -47,8 +47,8 @@ class PluginInstallTaskManager extends AbstractTaskManager {
 	 * @return array
 	 */
 	public function add_thirty_seconds_schedule( $schedules ) {
-		if ( ! array_key_exists( 'thirty_seconds', $schedules ) || 30 !== $schedules[ 'thirty_seconds' ][ 'interval' ] ) {
-			$schedules[ 'thirty_seconds' ] = array(
+		if ( ! array_key_exists( 'thirty_seconds', $schedules ) || 30 !== $schedules['thirty_seconds']['interval'] ) {
+			$schedules['thirty_seconds'] = array(
 				'interval' => 30,
 				'display'  => __( 'Once Every Thirty Seconds' ),
 			);
@@ -86,10 +86,10 @@ class PluginInstallTaskManager extends AbstractTaskManager {
 
 		// Recreate the PluginInstall task from the associative array.
 		$plugin_install_task = new PluginInstallTask(
-			$plugin_to_install[ 'slug' ],
-			$plugin_to_install[ 'activate' ],
-			$plugin_to_install[ 'priority' ],
-			$plugin_to_install[ 'retries' ]
+			$plugin_to_install['slug'],
+			$plugin_to_install['activate'],
+			$plugin_to_install['priority'],
+			$plugin_to_install['retries']
 		);
 
 		// Update status to the current slug being installed.
@@ -143,8 +143,8 @@ class PluginInstallTaskManager extends AbstractTaskManager {
 			Check if there is an already existing PluginInstallTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin[ 'slug' ] !== $plugin_install_task->get_slug() ) {
-				$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			if ( $queued_plugin['slug'] !== $plugin_install_task->get_slug() ) {
+				$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 			}
 		}
 
@@ -175,8 +175,8 @@ class PluginInstallTaskManager extends AbstractTaskManager {
 			/*
 			If the Plugin slug does not match add it back to the queue.
 			*/
-			if ( $queued_plugin[ 'slug' ] !== $plugin ) {
-				$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			if ( $queued_plugin['slug'] !== $plugin ) {
+				$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 			}
 		}
 

--- a/includes/TaskManagers/PluginUninstallTaskManager.php
+++ b/includes/TaskManagers/PluginUninstallTaskManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 
 use NewfoldLabs\WP\Module\Installer\Data\Plugins;
@@ -10,46 +11,44 @@ use NewfoldLabs\WP\Module\Installer\Services\PluginUninstaller;
 /**
  * Manages the execution of PluginUninstallTasks.
  */
-class PluginUninstallTaskManager {
+class PluginUninstallTaskManager extends AbstractTaskManager {
 
 	/**
 	 * The number of times a PluginUninstallTask can be retried.
 	 *
 	 * @var int
 	 */
-	private static $retry_limit = 2;
+	protected static $retry_limit = 2;
 
 	/**
 	 * Name of the PluginUninstallTask Queue.
 	 *
 	 * @var string
 	 */
-	private static $queue_name = 'plugin_uninstall_queue';
+	protected static $queue_name = 'plugin_uninstall_queue';
+
+	/**
+	 * Name of the PluginUninstallTask Hook.
+	 *
+	 * @var string
+	 */
+	protected static $hook_name = 'nfd_module_installer_plugin_uninstall_cron';
 
 	/**
 	 * PluginUninstallTaskManager constructor.
 	 */
 	public function __construct() {
-		// Ensure there is a Ten second option in the cron schedules
-		add_filter( 'cron_schedules', array( $this, 'add_ten_seconds_schedule' ) );
+		parent::__construct();
 
 		// Ten second cron hook
-		add_action( 'nfd_module_installer_plugin_uninstall_cron', array( $this, 'uninstall' ) );
+		add_action( self::$hook_name, array( $this, 'uninstall' ) );
 
 		// Register the cron task
-		if ( ! wp_next_scheduled( 'nfd_module_installer_plugin_uninstall_cron' ) ) {
-			wp_schedule_event( time(), 'ten_seconds', 'nfd_module_installer_plugin_uninstall_cron' );
+		if ( ! wp_next_scheduled( self::$hook_name ) ) {
+			wp_schedule_event( time(), 'ten_seconds', self::$hook_name );
 		}
 	}
 
-	/**
-	 * Retrieve the Queue Name for the TaskManager to perform Plugin Uninstalls.
-	 *
-	 * @return string
-	 */
-	public static function get_queue_name() {
-		return self::$queue_name;
-	}
 
 	/**
 	 * Adds ten seconds option in the cron schedule.
@@ -58,8 +57,8 @@ class PluginUninstallTaskManager {
 	 * @return array
 	 */
 	public function add_ten_seconds_schedule( $schedules ) {
-		if ( ! array_key_exists( 'ten_seconds', $schedules ) || 10 !== $schedules['ten_seconds']['interval'] ) {
-			$schedules['ten_seconds'] = array(
+		if ( ! array_key_exists( 'ten_seconds', $schedules ) || 10 !== $schedules[ 'ten_seconds' ][ 'interval' ] ) {
+			$schedules[ 'ten_seconds' ] = array(
 				'interval' => 10,
 				'display'  => __( 'Once Every Ten Seconds' ),
 			);
@@ -86,6 +85,7 @@ class PluginUninstallTaskManager {
 		*/
 		$plugin_to_uninstall = array_shift( $plugins );
 		if ( ! $plugin_to_uninstall ) {
+			wp_unschedule_event( self::get_hook_name() );
 			return true;
 		}
 
@@ -94,9 +94,9 @@ class PluginUninstallTaskManager {
 
 		// Recreate the PluginInstall task from the associative array.
 		$plugin_uninstall_task = new PluginUninstallTask(
-			$plugin_to_uninstall['slug'],
-			$plugin_to_uninstall['priority'],
-			$plugin_to_uninstall['retries']
+			$plugin_to_uninstall[ 'slug' ],
+			$plugin_to_uninstall[ 'priority' ],
+			$plugin_to_uninstall[ 'retries' ]
 		);
 
 		// Execute the PluginUninstall Task.
@@ -146,7 +146,7 @@ class PluginUninstallTaskManager {
 
 		$plugin_list = Plugins::get_squashed();
 		// Gets the specified path for the Plugin from the predefined list
-		$plugin_path = $plugin_list[ $plugin_uninstall_task->get_slug() ]['path'];
+		$plugin_path = $plugin_list[ $plugin_uninstall_task->get_slug() ][ 'path' ];
 
 		if ( ! PluginUninstaller::is_plugin_installed( $plugin_path ) ) {
 			return true;
@@ -158,10 +158,10 @@ class PluginUninstallTaskManager {
 			Check if there is an already existing PluginUninstallTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin['slug'] === $plugin_uninstall_task->get_slug() ) {
+			if ( $queued_plugin[ 'slug' ] === $plugin_uninstall_task->get_slug() ) {
 				return false;
 			}
-			$queue->insert( $queued_plugin, $queued_plugin['priority'] );
+			$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
 		}
 
 		// Insert a new PluginUninstallTask at the appropriate position in the queue.
@@ -171,16 +171,5 @@ class PluginUninstallTaskManager {
 		);
 
 		return \update_option( Options::get_option_name( self::$queue_name ), $queue->to_array() );
-	}
-
-	/**
-	 * Returns the status of given plugin slug - uninstalling/completed.
-	 *
-	 * @param string $plugin Plugin Slug
-	 * @return string|false
-	 */
-	public static function status( $plugin ) {
-		$plugins = \get_option( Options::get_option_name( self::$queue_name ), array() );
-		return array_search( $plugin, array_column( $plugins, 'slug' ), true );
 	}
 }

--- a/includes/TaskManagers/PluginUninstallTaskManager.php
+++ b/includes/TaskManagers/PluginUninstallTaskManager.php
@@ -57,8 +57,8 @@ class PluginUninstallTaskManager extends AbstractTaskManager {
 	 * @return array
 	 */
 	public function add_ten_seconds_schedule( $schedules ) {
-		if ( ! array_key_exists( 'ten_seconds', $schedules ) || 10 !== $schedules[ 'ten_seconds' ][ 'interval' ] ) {
-			$schedules[ 'ten_seconds' ] = array(
+		if ( ! array_key_exists( 'ten_seconds', $schedules ) || 10 !== $schedules['ten_seconds']['interval'] ) {
+			$schedules['ten_seconds'] = array(
 				'interval' => 10,
 				'display'  => __( 'Once Every Ten Seconds' ),
 			);
@@ -94,9 +94,9 @@ class PluginUninstallTaskManager extends AbstractTaskManager {
 
 		// Recreate the PluginInstall task from the associative array.
 		$plugin_uninstall_task = new PluginUninstallTask(
-			$plugin_to_uninstall[ 'slug' ],
-			$plugin_to_uninstall[ 'priority' ],
-			$plugin_to_uninstall[ 'retries' ]
+			$plugin_to_uninstall['slug'],
+			$plugin_to_uninstall['priority'],
+			$plugin_to_uninstall['retries']
 		);
 
 		// Execute the PluginUninstall Task.
@@ -146,7 +146,7 @@ class PluginUninstallTaskManager extends AbstractTaskManager {
 
 		$plugin_list = Plugins::get_squashed();
 		// Gets the specified path for the Plugin from the predefined list
-		$plugin_path = $plugin_list[ $plugin_uninstall_task->get_slug() ][ 'path' ];
+		$plugin_path = $plugin_list[ $plugin_uninstall_task->get_slug() ]['path'];
 
 		if ( ! PluginUninstaller::is_plugin_installed( $plugin_path ) ) {
 			return true;
@@ -158,10 +158,10 @@ class PluginUninstallTaskManager extends AbstractTaskManager {
 			Check if there is an already existing PluginUninstallTask in the queue
 			for a given slug.
 			*/
-			if ( $queued_plugin[ 'slug' ] === $plugin_uninstall_task->get_slug() ) {
+			if ( $queued_plugin['slug'] === $plugin_uninstall_task->get_slug() ) {
 				return false;
 			}
-			$queue->insert( $queued_plugin, $queued_plugin[ 'priority' ] );
+			$queue->insert( $queued_plugin, $queued_plugin['priority'] );
 		}
 
 		// Insert a new PluginUninstallTask at the appropriate position in the queue.

--- a/includes/TaskManagers/TaskManager.php
+++ b/includes/TaskManagers/TaskManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 
 use NewfoldLabs\WP\Module\Installer\Data\Options;
@@ -25,8 +26,13 @@ final class TaskManager {
 	 * Constructor that registers all the TaskManagers.
 	 */
 	public function __construct() {
+		TaskManagerSchedules::init();
+
+		/**
+		 * @var $task_manager PluginUninstallTaskManager|PluginDeactivationTaskManager|ThemeInstallTaskManager|PluginInstallTaskManager|PluginActivationTaskManager
+		 */
 		foreach ( $this->task_managers as $task_manager ) {
-			if ( ! empty( get_option( Options::get_option_name( $task_manager::get_queue_name() ), array() ) ) ) {
+			if ( wp_next_scheduled( $task_manager::get_hook_name() ) || ! empty( get_option( Options::get_option_name( $task_manager::get_queue_name() ), array() ) ) ) {
 				new $task_manager();
 			}
 		}

--- a/includes/TaskManagers/TaskManager.php
+++ b/includes/TaskManagers/TaskManager.php
@@ -29,6 +29,8 @@ final class TaskManager {
 		TaskManagerSchedules::init();
 
 		/**
+		 * Task Manager Class
+		 *
 		 * @var $task_manager PluginUninstallTaskManager|PluginDeactivationTaskManager|ThemeInstallTaskManager|PluginInstallTaskManager|PluginActivationTaskManager
 		 */
 		foreach ( $this->task_managers as $task_manager ) {

--- a/includes/TaskManagers/TaskManagerSchedules.php
+++ b/includes/TaskManagers/TaskManagerSchedules.php
@@ -8,35 +8,14 @@ namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 abstract class TaskManagerSchedules {
 
 	/**
-	 * List of Task Managers.
-	 *
-	 * @var array
-	 */
-	protected static $schedules = array();
-
-	/**
 	 * Init the Task Manager Schedules class
 	 */
 	public static function init() {
 		static $initialized = false;
 
 		if ( ! $initialized ) {
-			self::init_schedules();
 			add_filter( 'cron_schedules', array( __CLASS__, 'add_schedules' ) );
 		}
-	}
-
-	protected static function init_schedules() {
-		self::$schedules = array(
-			'thirty_seconds' => array(
-				'interval' => 30,
-				'display'  => __( 'Once Every Thirty Seconds' ),
-			),
-			'ten_seconds'    => array(
-				'interval' => 10,
-				'display'  => __( 'Once Every Ten Seconds' ),
-			),
-		);
 	}
 
 	/**
@@ -46,8 +25,19 @@ abstract class TaskManagerSchedules {
 	 * @return array
 	 */
 	public static function add_schedules( $schedules ) {
-		foreach ( self::$schedules as $schedule_slug => $schedule_data ) {
-			if ( ! array_key_exists( $schedule_slug, $schedules ) || $schedule_data[ 'interval' ] !== $schedules[ $schedule_slug ][ 'interval' ] ) {
+		$schedules_to_add = array(
+			'thirty_seconds' => array(
+				'interval' => 30,
+				'display'  => __( 'Once Every Thirty Seconds' ),
+			),
+			'ten_seconds'    => array(
+				'interval' => 10,
+				'display'  => __( 'Once Every Ten Seconds' ),
+			),
+		);
+
+		foreach ( $schedules_to_add as $schedule_slug => $schedule_data ) {
+			if ( ! array_key_exists( $schedule_slug, $schedules ) || $schedule_data['interval'] !== $schedules[ $schedule_slug ]['interval'] ) {
 				$schedules[ $schedule_slug ] = $schedule_data;
 			}
 		}

--- a/includes/TaskManagers/TaskManagerSchedules.php
+++ b/includes/TaskManagers/TaskManagerSchedules.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
+
+/**
+ * Class TaskManagerSchedules
+ */
+abstract class TaskManagerSchedules {
+
+	/**
+	 * List of Task Managers.
+	 *
+	 * @var array
+	 */
+	protected static $schedules = array();
+
+	/**
+	 * Init the Task Manager Schedules class
+	 */
+	public static function init() {
+		static $initialized = false;
+
+		if ( ! $initialized ) {
+			self::init_schedules();
+			add_filter( 'cron_schedules', array( __CLASS__, 'add_schedules' ) );
+		}
+	}
+
+	protected static function init_schedules() {
+		self::$schedules = array(
+			'thirty_seconds' => array(
+				'interval' => 30,
+				'display'  => __( 'Once Every Thirty Seconds' ),
+			),
+			'ten_seconds'    => array(
+				'interval' => 10,
+				'display'  => __( 'Once Every Ten Seconds' ),
+			),
+		);
+	}
+
+	/**
+	 * Adds a task manager cron schedule.
+	 *
+	 * @param array $schedules The existing cron schedule.
+	 * @return array
+	 */
+	public static function add_schedules( $schedules ) {
+		foreach ( self::$schedules as $schedule_slug => $schedule_data ) {
+			if ( ! array_key_exists( $schedule_slug, $schedules ) || $schedule_data[ 'interval' ] !== $schedules[ $schedule_slug ][ 'interval' ] ) {
+				$schedules[ $schedule_slug ] = $schedule_data;
+			}
+		}
+
+		return $schedules;
+	}
+}

--- a/includes/TaskManagers/ThemeInstallTaskManager.php
+++ b/includes/TaskManagers/ThemeInstallTaskManager.php
@@ -23,7 +23,7 @@ class ThemeInstallTaskManager extends AbstractTaskManager {
 	 *
 	 * @var string
 	 */
-	protected  static $hook_name = 'nfd_module_installer_theme_install_cron';
+	protected static $hook_name = 'nfd_module_installer_theme_install_cron';
 
 	/**
 	 * ThemeInstallTaskManager constructor.
@@ -59,10 +59,10 @@ class ThemeInstallTaskManager extends AbstractTaskManager {
 		\update_option( Options::get_option_name( self::$queue_name ), $themes );
 
 		$theme_install_task = new ThemeInstallTask(
-			$theme_to_install[ 'slug' ],
-			$theme_to_install[ 'activate' ],
-			$theme_to_install[ 'priority' ],
-			$theme_to_install[ 'retries' ]
+			$theme_to_install['slug'],
+			$theme_to_install['activate'],
+			$theme_to_install['priority'],
+			$theme_to_install['retries']
 		);
 
 		// Update status to the current slug being installed.
@@ -118,10 +118,10 @@ class ThemeInstallTaskManager extends AbstractTaskManager {
 
 		// Recreate the ThemeInstallTask from the associative array.
 		$theme_install_task = new ThemeInstallTask(
-			$theme_to_install[ 'slug' ],
-			$theme_to_install[ 'activate' ],
-			$theme_to_install[ 'priority' ],
-			$theme_to_install[ 'retries' ]
+			$theme_to_install['slug'],
+			$theme_to_install['activate'],
+			$theme_to_install['priority'],
+			$theme_to_install['retries']
 		);
 
 		// Update status to the current slug being installed.
@@ -172,11 +172,11 @@ class ThemeInstallTaskManager extends AbstractTaskManager {
 			Check if there is an already existing ThemeInstallTask in the queue
 			for a given slug and activation criteria.
 			*/
-			if ( $queued_theme[ 'slug' ] === $theme_install_task->get_slug()
-				&& $queued_theme[ 'activate' ] === $theme_install_task->get_activate() ) {
+			if ( $queued_theme['slug'] === $theme_install_task->get_slug()
+				&& $queued_theme['activate'] === $theme_install_task->get_activate() ) {
 				return false;
 			}
-			$queue->insert( $queued_theme, $queued_theme[ 'priority' ] );
+			$queue->insert( $queued_theme, $queued_theme['priority'] );
 		}
 
 		// Insert a new ThemeInstallTask at the appropriate position in the queue.

--- a/includes/TaskManagers/ThemeInstallTaskManager.php
+++ b/includes/TaskManagers/ThemeInstallTaskManager.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace NewfoldLabs\WP\Module\Installer\TaskManagers;
 
 use NewfoldLabs\WP\Module\Installer\Data\Options;
@@ -8,62 +9,35 @@ use NewfoldLabs\WP\Module\Installer\Models\PriorityQueue;
 /**
  * Manages the execution of ThemeInstallTasks.
  */
-class ThemeInstallTaskManager {
-
-	/**
-	 * The number of times a ThemeInstallTask can be retried.
-	 *
-	 * @var int
-	 */
-	private static $retry_limit = 1;
+class ThemeInstallTaskManager extends AbstractTaskManager {
 
 	/**
 	 * Name of the ThemeInstallTaskManager Queue.
 	 *
 	 * @var string
 	 */
-	private static $queue_name = 'theme_install_queue';
+	protected static $queue_name = 'theme_install_queue';
+
+	/**
+	 * Name of the ThemeInstallTaskManager Hook.
+	 *
+	 * @var string
+	 */
+	protected  static $hook_name = 'nfd_module_installer_theme_install_cron';
 
 	/**
 	 * ThemeInstallTaskManager constructor.
 	 */
 	public function __construct() {
-		// Ensure there is a ten second option in the cron schedules
-		add_filter( 'cron_schedules', array( $this, 'add_ten_seconds_schedule' ) );
+		parent::__construct();
 
 		// Ten second cron hook
-		add_action( 'nfd_module_installer_theme_install_cron', array( $this, 'install' ) );
+		add_action( self::$hook_name, array( $this, 'install' ) );
 
 		// Register the cron task
-		if ( ! wp_next_scheduled( 'nfd_module_installer_theme_install_cron' ) ) {
-			wp_schedule_event( time(), 'ten_seconds', 'nfd_module_installer_theme_install_cron' );
+		if ( ! wp_next_scheduled( self::$hook_name ) ) {
+			wp_schedule_event( time(), 'ten_seconds', self::$hook_name );
 		}
-	}
-
-	/**
-	 * Retrieve the Queue Name for the TaskManager to perform Theme installation.
-	 *
-	 * @return string
-	 */
-	public static function get_queue_name() {
-		return self::$queue_name;
-	}
-
-	/**
-	 * Adds ten seconds option in the cron schedule.
-	 *
-	 * @param array $schedules Cron Schedule duration
-	 * @return array
-	 */
-	public function add_ten_seconds_schedule( $schedules ) {
-		if ( ! array_key_exists( 'ten_seconds', $schedules ) || 10 !== $schedules['ten_seconds']['interval'] ) {
-			$schedules['ten_seconds'] = array(
-				'interval' => 10,
-				'display'  => __( 'Once Every Ten Seconds' ),
-			);
-		}
-
-		return $schedules;
 	}
 
 	/**
@@ -85,10 +59,10 @@ class ThemeInstallTaskManager {
 		\update_option( Options::get_option_name( self::$queue_name ), $themes );
 
 		$theme_install_task = new ThemeInstallTask(
-			$theme_to_install['slug'],
-			$theme_to_install['activate'],
-			$theme_to_install['priority'],
-			$theme_to_install['retries']
+			$theme_to_install[ 'slug' ],
+			$theme_to_install[ 'activate' ],
+			$theme_to_install[ 'priority' ],
+			$theme_to_install[ 'retries' ]
 		);
 
 		// Update status to the current slug being installed.
@@ -106,7 +80,7 @@ class ThemeInstallTaskManager {
 				then re-queue the task at the end of the queue to be retried.
 			*/
 			if ( $theme_install_task->get_retries() <= self::$retry_limit ) {
-					array_push( $themes, $theme_install_task->to_array() );
+				array_push( $themes, $theme_install_task->to_array() );
 			}
 		}
 
@@ -138,15 +112,16 @@ class ThemeInstallTaskManager {
 		*/
 		$theme_to_install = array_shift( $themes );
 		if ( ! $theme_to_install ) {
+			self::complete();
 			return true;
 		}
 
 		// Recreate the ThemeInstallTask from the associative array.
 		$theme_install_task = new ThemeInstallTask(
-			$theme_to_install['slug'],
-			$theme_to_install['activate'],
-			$theme_to_install['priority'],
-			$theme_to_install['retries']
+			$theme_to_install[ 'slug' ],
+			$theme_to_install[ 'activate' ],
+			$theme_to_install[ 'priority' ],
+			$theme_to_install[ 'retries' ]
 		);
 
 		// Update status to the current slug being installed.
@@ -164,13 +139,13 @@ class ThemeInstallTaskManager {
 				then re-queue the task at the end of the queue to be retried.
 			*/
 			if ( $theme_install_task->get_retries() <= self::$retry_limit ) {
-					array_push( $themes, $theme_install_task->to_array() );
+				array_push( $themes, $theme_install_task->to_array() );
 			}
 		}
 
 		// If there are no more themes to be installed then change the status to completed.
 		if ( empty( $themes ) ) {
-			\update_option( Options::get_option_name( 'theme_init_status' ), 'completed' );
+			self::complete();
 		}
 
 		// Update the theme install queue.
@@ -197,11 +172,11 @@ class ThemeInstallTaskManager {
 			Check if there is an already existing ThemeInstallTask in the queue
 			for a given slug and activation criteria.
 			*/
-			if ( $queued_theme['slug'] === $theme_install_task->get_slug()
-				&& $queued_theme['activate'] === $theme_install_task->get_activate() ) {
+			if ( $queued_theme[ 'slug' ] === $theme_install_task->get_slug()
+				&& $queued_theme[ 'activate' ] === $theme_install_task->get_activate() ) {
 				return false;
 			}
-			$queue->insert( $queued_theme, $queued_theme['priority'] );
+			$queue->insert( $queued_theme, $queued_theme[ 'priority' ] );
 		}
 
 		// Insert a new ThemeInstallTask at the appropriate position in the queue.
@@ -213,14 +188,14 @@ class ThemeInstallTaskManager {
 		return \update_option( Options::get_option_name( self::$queue_name ), $queue->to_array() );
 	}
 
+
 	/**
-	 * Returns the status of given plugin slug - installing/completed.
+	 * Clear all the hook scheduling and update the status option
 	 *
-	 * @param string $theme Theme Slug
-	 * @return string|false
+	 * @return bool
 	 */
-	public static function status( $theme ) {
-		$themes = \get_option( Options::get_option_name( self::$queue_name ), array() );
-		return array_search( $theme, array_column( $themes, 'slug' ), true );
+	private static function complete() {
+		wp_clear_scheduled_hook( self::get_hook_name() );
+		return \update_option( Options::get_option_name( 'theme_init_status' ), 'completed' );
 	}
 }


### PR DESCRIPTION
## Proposed changes

This PR includes a code refactoring of the TaskManager section and additional checks to unsure that the Task class is being instanced if its managed the cron is scheduled.

In addition the custom schedules are included from a new `TaskManagerSchedules` class that handles them.

There was a lot of repetitive code that was abstracted and put in an `AbstractTaskManager` class that then is extended by all the other tasks manager classes.

---
 
Initially this PR was meant to solve issues related to cron that were randomly displaying in the log, such as:
`Cron unschedule event error for hook: nfd_module_installer_plugin_deactivation_event, Error code: could_not_set, Error message: The cron event list could not be saved., Data: {"schedule":false,"args":[]}`

This kind of issue present when a cron is executed multiple and simultaneous times, so that trigger an error with the cron option update. This is an issue that affect WordPress since 6.1 version. (in the last section i'm attaching the related WP Core thread)

For this PR we are including the refactoring and additional checks and cron clearing after their completion as is the best we can do for the moment. We can evaluate further investigation for the future.

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Type of Change

<!-- What types of changes does your code introduce? -->
<!-- _Put an `x` in the boxes that apply_ -->

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [x] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [ ] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Video

<!-- Add a short video demonstrating where the change takes effect and how to can be reproduced by reviewers -->
<!-- On macOS press cmd+shift+5 to open the screen recording tool. It will save the video to the desktop  -->

<!-- Drag and drop the video file into the GitHub editor to attach it -->

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [ ] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

Here the thread related to the WordPress Cron issue:
- https://core.trac.wordpress.org/ticket/57271

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->
<!-- Now is a good time to create additional tickets for any necessary follow-up work. -->