### PR TITLE
Add `matrix.php == '7.3'` checks and PR coverage report

### DIFF
--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,7 +20,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:8.0
+        image: mysql:5.7
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: tests-wordpress

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -91,7 +91,9 @@ jobs:
         if: ${{ hashFiles('wp-content') != '' }} # TODO: This may be incorrect since it's a directory.
         run: sudo chmod -R a+w wp-content
 
+      # On main, there will be a previous coverage report. On PRs we create a new directory using the commit SHA.
       - name: Clear previous code coverage
+        if: ${{ (matrix.php == '7.3') && (github.ref == 'refs/heads/main') }}
         run: |
           rm -rf gh-pages/phpunit || true;
           mkdir gh-pages/phpunit || true;
@@ -108,7 +110,7 @@ jobs:
         if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
         run: |
           vendor/bin/phpcov merge --clover clover.xml tests/_output/;
-          vendor/bin/phpcov merge --clover gh-pages/phpunit/clover.xml --php gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/phpunit.cov --html gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/html/ tests/_output/;
+          vendor/bin/phpcov merge --clover gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/clover.xml --php gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/phpunit.cov --html gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/html/ tests/_output/;
 
       # On main, we want it output to a different path
       - name: Merge code coverage for main

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -29,8 +29,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     strategy:
-        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
       matrix: # Supported PHP versions
+        php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
 
     steps:
       - name: Checkout

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -158,14 +158,14 @@ jobs:
       - name: Add coverage badge to PR comment
         if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
         run: |
-          echo "[![Code Coverage ](https://newfold-labs.github.io/wp-module-data/${{ github.event.pull_request.head.sha }}/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-data/${{ github.event.pull_request.head.sha }}/phpunit/html/)" >> coverage-comment.md
+          echo "[![Code Coverage ](https://newfold-labs.github.io/wp-module-installer/${{ github.event.pull_request.head.sha }}/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-installer/${{ github.event.pull_request.head.sha }}/phpunit/html/)" >> coverage-comment.md
           echo "" >> coverage-comment.md
           echo "" >> coverage-comment.md
 
       - name: Add coverage report link to PR comment
         if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
         run: |
-          echo "${{ format('[project coverage report {0}%](https://newfold-labs.github.io/wp-module-data/{1}/phpunit/html/) @ {2}', steps.coverage-percentage.outputs.coverage-rounded, github.event.pull_request.head.sha, github.event.pull_request.head.sha) }}" >> coverage-comment.md
+          echo "${{ format('[project coverage report {0}%](https://newfold-labs.github.io/wp-module-installer/{1}/phpunit/html/) @ {2}', steps.coverage-percentage.outputs.coverage-rounded, github.event.pull_request.head.sha, github.event.pull_request.head.sha) }}" >> coverage-comment.md
           echo "" >> coverage-comment.md
           echo "" >> coverage-comment.md
 

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -94,6 +94,7 @@ jobs:
           mkdir gh-pages/phpunit || true;
 
       - name: Run unit tests
+        if: ${{ hashFiles('tests/phpunit/bootstrap.php') != '' }}
         run: XDEBUG_MODE=coverage vendor/bin/phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov --debug
 
       - name: Run wpunit tests

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -85,6 +85,7 @@ jobs:
         run: composer install -v
 
       - name: Allow writing to wp-content
+        if: ${{ hashFiles('wp-content') != '' }}
         run: sudo chmod -R a+w wp-content
 
       - name: Clear previous code coverage

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -7,10 +7,15 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [ opened, reopened, ready_for_review, synchronize ]
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
 
-  codecoverage-main:
+  codecoverage:
     runs-on: ubuntu-latest
 
     services:
@@ -30,26 +35,31 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Check does gh-pages branch need to be created
-        run: |
-          if [[ $(git branch -l gh-pages) == "" ]]; then
-            gh_pages_branch_needed=true
-          else
-            gh_pages_branch_needed=false
-          fi
-          echo "GH_PAGES_BRANCH_NEEDED=$gh_pages_branch_needed" >> $GITHUB_ENV;
-          mkdir gh-pages
-
-      - name:  Maybe create gh-pages branch
-        if: ${{ env.GH_PAGES_BRANCH_NEEDED }}
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gh-pages
-          force_orphan: true
-          allow_empty_commit: true
-          commit_message: "🤖 Creating gh-pages branch"
+          fetch-depth: 0 # attempting to get all branch names.
+
+      #      - name: Check does gh-pages branch need to be created
+      #        run: |
+      #          git branch -l;
+      #          if [[ $(git branch -l gh-pages) == "" ]]; then
+      #            gh_pages_branch_needed=true;
+      #            echo "gh-pages branch is needed";
+      #          else
+      #            gh_pages_branch_needed=false
+      #            echo "gh-pages branch already exists";
+      #          fi
+      #          echo "GH_PAGES_BRANCH_NEEDED=$gh_pages_branch_needed" >> $GITHUB_ENV;
+      #          mkdir gh-pages
+      #
+      #      - name:  Maybe create gh-pages branch
+      #        if: ${{ env.GH_PAGES_BRANCH_NEEDED }}
+      #        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      #        with:
+      #          github_token: ${{ secrets.GITHUB_TOKEN }}
+      #          publish_dir: ./gh-pages
+      #          force_orphan: true
+      #          allow_empty_commit: true
+      #          commit_message: "🤖 Creating gh-pages branch"
 
       - name: Checkout GitHub Pages branch for code coverage report
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,28 +92,93 @@ jobs:
           rm -rf gh-pages/phpunit || true;
           mkdir gh-pages/phpunit || true;
 
-      - name: Run tests
-        run: XDEBUG_MODE=coverage composer test-coverage
+      - name: Run unit tests
+        run: XDEBUG_MODE=coverage vendor/bin/phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov --debug
 
-      - name: Merge code coverage
-        run: vendor/bin/phpcov merge --clover gh-pages/phpunit/clover.xml --php gh-pages/phpunit/phpunit.cov --html gh-pages/phpunit/html/ tests/_output/;
+      - name: Run wpunit tests
+        run: XDEBUG_MODE=coverage vendor/bin/codecept run wpunit --coverage tests/_output/wpunit.cov --debug
+
+      # For PRs, we'll generate the coverage report on each pushed commit
+      - name: Merge code coverage for PR
+        if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
+        run: |
+          vendor/bin/phpcov merge --clover clover.xml tests/_output/;
+          vendor/bin/phpcov merge --clover gh-pages/phpunit/clover.xml --php gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/phpunit.cov --html gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/html/ tests/_output/;
+
+      # On main, we want it output to a different path
+      - name: Merge code coverage for main
+        if: ${{ (matrix.php == '7.3') && (github.ref == 'refs/heads/main') }}
+        run: |
+          vendor/bin/phpcov merge --clover clover.xml tests/_output/;
+          vendor/bin/phpcov merge --clover gh-pages/phpunit/clover.xml --php gh-pages/phpunit/phpunit.cov --html gh-pages/phpunit/html/ tests/_output/;
+
+      # This makes the coverage percentage available in `{{ steps.coverage-percentage.outputs.coverage-rounded }}`.
+      - name: Check test coverage
+        if: ${{ matrix.php == '7.3' }}
+        uses: johanvanhelden/gha-clover-test-coverage-check@2543c79a701f179bd63aa14c16c6938c509b2cec # v1
+        id: coverage-percentage
+        with:
+          percentage: 25
+          exit: false
+          filename: clover.xml
+          rounded-precision: "0"
 
       # See: https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/
       - name: Add `.nojekyll` file so code coverage report successfully deploys to gh-pages
-        working-directory: gh-pages/phpunit
+        if: ${{ (matrix.php == '7.3') }}
+        working-directory: gh-pages
         run: |
           touch .nojekyll
           git add -- .nojekyll *
 
-      - name: Update README badge
-        run: php-coverage-badger gh-pages/phpunit/clover.xml gh-pages/phpunit/coverage.svg
+      - name: Update README coverage badge
+        if: ${{ (matrix.php == '7.3') && (github.ref == 'refs/heads/main') }} # only commit on main, on the PHP version we're using in production.
+        run: php-coverage-badger clover.xml gh-pages/phpunit/coverage.svg
+
+      - name: Generate PR coverage badge
+        if: ${{ (matrix.php == '7.3') && github.event_name == 'pull_request' }}
+        run: php-coverage-badger clover.xml gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/coverage.svg
 
       - name: Commit code coverage to gh-pages
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+        if: ${{ matrix.php == '7.3' }}
+        uses: stefanzweifel/git-auto-commit-action@e348103e9026cc0eee72ae06630dbe30c8bf7a79 # v5.1.0
         with:
           repository: gh-pages
           branch: gh-pages
-          commit_message: "🤖 Save code coverage report to gh-pages" # TODO: include the percentage change in the message.
+          commit_message: ${{ format('🤖 Save code coverage report to gh-pages {0}%', steps.coverage-percentage.outputs.coverage-rounded) }}
           commit_options: ""
         env:
           GITHUB_TOKEN: "${{ github.token }}"
+
+      - name: Add coverage badge to PR comment
+        if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
+        run: |
+          echo "[![Code Coverage ](https://newfold-labs.github.io/wp-module-data/${{ github.event.pull_request.head.sha }}/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-data/${{ github.event.pull_request.head.sha }}/phpunit/html/)" >> coverage-comment.md
+          echo "" >> coverage-comment.md
+          echo "" >> coverage-comment.md
+
+      - name: Add coverage report link to PR comment
+        if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
+        run: |
+          echo "${{ format('[project coverage report {0}%](https://newfold-labs.github.io/wp-module-data/{1}/phpunit/html/) @ {2}', steps.coverage-percentage.outputs.coverage-rounded, github.event.pull_request.head.sha, github.event.pull_request.head.sha) }}" >> coverage-comment.md
+          echo "" >> coverage-comment.md
+          echo "" >> coverage-comment.md
+
+      - name: Add phpcov uncovered lines report to PR comment
+        if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
+        continue-on-error: true # phpcov can fail if there are no uncovered lines
+        run: |
+          BRANCHED_COMMIT=$(git rev-list origin..HEAD | tail -n 1);
+          echo "BRANCHED_COMMIT=$BRANCHED_COMMIT"
+          git diff $BRANCHED_COMMIT...${{ github.event.pull_request.head.sha }} > branch.diff;
+          cat branch.diff;
+          OUTPUT=${vendor/bin/phpcov patch-coverage --path-prefix $(pwd) ./gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/phpunit.cov branch.diff || true}
+          echo $OUTPUT;
+          echo "$OUTPUT" >> coverage-comment.md
+
+      - name: Add coverage PR comment
+        uses: mshick/add-pr-comment@b8f338c590a895d50bcbfa6c5859251edc8952fc # v2.8.2
+        if: ${{ matrix.php == '7.3' && github.event_name == 'pull_request' }}
+        with:
+          message-id: coverage-report
+          message-path: coverage-comment.md

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -20,17 +20,17 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
-        env:
+        image: mysql:5.7 # Password auth did not work on 8.0 on PHP 7.3, it did seem to work for PHP 7.4+
+        env: # These are the same username and password as the wp-env container defaults
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: tests-wordpress
-        ports:
+        ports: # This mapping matches the .wp-env.json configuration
           - 33306:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     strategy:
-      matrix:
         php: [ '7.3', '7.4', '8.0', '8.1', '8.2', '8.3' ]
+      matrix: # Supported PHP versions
 
     steps:
       - name: Checkout
@@ -38,6 +38,9 @@ jobs:
         with:
           fetch-depth: 0 # attempting to get all branch names.
 
+      # TODO: a DEPLOY_KEY is needed to enable gh-pages for the first time (the branch can be created and pushed but
+      # it will not be reachable as a website).
+      # Consider @see https://github.com/peaceiris/actions-gh-pages
       #      - name: Check does gh-pages branch need to be created
       #        run: |
       #          git branch -l;
@@ -85,7 +88,7 @@ jobs:
         run: composer install -v
 
       - name: Allow writing to wp-content
-        if: ${{ hashFiles('wp-content') != '' }}
+        if: ${{ hashFiles('wp-content') != '' }} # TODO: This may be incorrect since it's a directory.
         run: sudo chmod -R a+w wp-content
 
       - name: Clear previous code coverage
@@ -94,7 +97,7 @@ jobs:
           mkdir gh-pages/phpunit || true;
 
       - name: Run unit tests
-        if: ${{ hashFiles('tests/phpunit/bootstrap.php') != '' }}
+        if: ${{ hashFiles('tests/phpunit/bootstrap.php') != '' }} # Only run unit tests if they are present.
         run: XDEBUG_MODE=coverage vendor/bin/phpunit --bootstrap tests/phpunit/bootstrap.php --coverage-php tests/_output/unit.cov --debug
 
       - name: Run wpunit tests

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ height="42" />
 # WordPress Installer Module
 [![Version Number](https://img.shields.io/github/v/release/newfold-labs/wp-module-installer?color=21a0ed&labelColor=333333)](https://github.com/newfold/wp-module-installer/releases)
 [![License](https://img.shields.io/github/license/newfold-labs/wp-module-installer?labelColor=333333&color=666666)](https://raw.githubusercontent.com/newfold-labs/wp-module-installer/master/LICENSE)
+[![PHPUnit](https://newfold-labs.github.io/wp-module-installer/phpunit/coverage.svg)](https://newfold-labs.github.io/wp-module-installer/phpunit/html)
 
 An installer for WordPress plugins and themes.
 


### PR DESCRIPTION
## Proposed changes

Previously
* the commit action would run on each workflow matrix run, and would fail when a second instance tried to commit. 
* the coverage report was only generated for commits to main

## Type of Change

* add `if: ${{ matrix.php == '7.3' }}` and similar to many steps
* outputs the coverage report for every push to a PR to `gh-pages/${{ github.event.pull_request.head.sha }}/phpunit/html`

#### Production

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Dependency update
- [ ] Refactoring / housekeeping (changes to files not directly related to functionality)

<!-- Bugfixes should explain how to reproduce the bug -->

#### Development

- [x] Tests
- [ ] Dependency update
- [ ] Environment update / refactoring
- [ ] Documentation Update

<!-- All PRs should endeavor to include tests -->
<!-- PRs with new tools or dependencies should explain how to use them -->

## Video

<img width="945" alt="Screenshot 2025-04-22 at 5 11 47 PM" src="https://github.com/user-attachments/assets/90b17979-6eef-4911-8d4f-b9b8e2f26598" />

https://github.com/newfold-labs/wp-module-data/pull/138#issuecomment-2815984258

<img width="926" alt="Screenshot 2025-04-22 at 5 34 02 PM" src="https://github.com/user-attachments/assets/ff091fd7-a988-4d47-aa6a-46c489bc0057" />

https://github.com/newfold-labs/wp-module-installer/tree/gh-pages

## Checklist

<!-- _Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._ -->

- [x] I have read the [CONTRIBUTING](https://github.com/bluehost/.github/blob/master/.github/contributing.md) doc
- [ ] I have viewed my change in a web-browser
- [ ] Linting and tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

<!-- 
## Pre-deployment Checklist

- [ ] E.g. environmental variables which need to be set before deployment will work.
- [ ] E.g. other tickets which need to be complete before an API this change relies on will be ready
-->

<!--
## Post-deployment Checklist

How can the change be verified?

- [ ] E.g. temporarily enable logging and observe specific logs.
- [ ] E.g. observe new data in a specific view or table.
-->

## Further comments

* The badge doesn't seem to appear all the time, although the `coverage.svg` file does exist
* In later PHP versions, we have a nice report in the PR comment, needs work to run on old PHP: https://github.com/BrianHenryIE/php-diff-test
