### PR TITLE
Minimally scope permissions in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -6,15 +6,15 @@ on:
       - 'main'
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 # Cancels all previous workflow runs for the branch that have not completed.
 concurrency:
   # The concurrency group contains the workflow name and the branch name.
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
-
-# Disable permissions for all available scopes by default.
-# Any needed permissions should be configured at the job level.
-permissions: {}
 
 jobs:
   translate:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -12,15 +12,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
 permissions: {}
 
 jobs:
   translate:
     name: 'Check and update translations'
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-translations.yml@main
+    permissions:
+      contents: write      # Required for callee translation automation to push commits and manage branches.
+      pull-requests: write # Required for callee gh-driven pull request create/update flows in the reusable workflow.
     with:
       text_domain: 'wp-module-installer'
     secrets:

--- a/.github/workflows/auto-translate.yml
+++ b/.github/workflows/auto-translate.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: write      # Required for callee translation automation to push commits and manage branches.
       pull-requests: write # Required for callee gh-driven pull request create/update flows in the reusable workflow.
+    timeout-minutes: 90
     with:
       text_domain: 'wp-module-installer'
     secrets:

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
+
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {} # Extracts branch name from environment only; no checkout or GitHub API calls.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -31,9 +31,9 @@ jobs:
   bluehost:
     name: Bluehost Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -43,9 +43,9 @@ jobs:
   bluehost-dev:
     name: Bluehost Dev Build and Test Playwright
     needs: setup
-    permissions:
-      contents: read
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
+    permissions:
+      contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -6,19 +6,19 @@ on:
       - main
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   setup:
     name: Setup
     runs-on: ubuntu-latest
-    permissions: {} # Extracts branch name from environment only; no checkout or GitHub API calls.
+    permissions: {} # No checkout or GitHub API usage; only derives branch name from GitHub env/context.
     timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
@@ -34,7 +34,7 @@ jobs:
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
-      contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
+      contents: read # Required for reusable workflow to clone module and plugin repos (private).
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
@@ -47,7 +47,7 @@ jobs:
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
-      contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
+      contents: read # Required for reusable workflow to clone module and plugin repos (private).
     timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}

--- a/.github/workflows/brand-plugin-test-playwright.yml
+++ b/.github/workflows/brand-plugin-test-playwright.yml
@@ -19,6 +19,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Extracts branch name from environment only; no checkout or GitHub API calls.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}
@@ -46,6 +48,7 @@ jobs:
     uses: newfold-labs/workflows/.github/workflows/module-plugin-test-playwright.yml@main
     permissions:
       contents: read # Required for callee checkouts of the module (this repo) and brand plugin repositories.
+    timeout-minutes: 120
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -21,6 +21,7 @@ jobs:
   get-repo-name:
     runs-on: ubuntu-latest
     permissions: {} # Uses github.repository context only; no checkout or GitHub API calls.
+    timeout-minutes: 5
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -34,6 +35,7 @@ jobs:
     permissions:
       contents: write      # Required for callee jobs to push merged coverage HTML to the gh-pages branch.
       pull-requests: write # Required for callee to post pull request coverage comments (e.g. add-pr-comment).
+    timeout-minutes: 120
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/codecoverage-main.yml
+++ b/.github/workflows/codecoverage-main.yml
@@ -13,12 +13,14 @@ on:
       - main
   workflow_dispatch:
 
-permissions:
-  contents: read
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   get-repo-name:
     runs-on: ubuntu-latest
+    permissions: {} # Uses github.repository context only; no checkout or GitHub API calls.
     outputs:
       repository-name: ${{ steps.repo-name.outputs.name }}
     steps:
@@ -28,10 +30,10 @@ jobs:
 
   codecoverage:
     needs: get-repo-name
-    permissions:
-      contents: write
-      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-codecoverage.yml@main
+    permissions:
+      contents: write      # Required for callee jobs to push merged coverage HTML to the gh-pages branch.
+      pull-requests: write # Required for callee to post pull request coverage comments (e.g. add-pr-comment).
     with:
       php-versions: '["7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
       coverage-php-version: '7.4'

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -18,6 +18,7 @@ jobs:
     permissions:
       contents: write      # Required for callee Crowdin download workflow to commit translation updates (when using default token paths).
       pull-requests: write # Required for callee Crowdin PR creation flow (see reusable workflow; PAT may also be used via secrets).
+    timeout-minutes: 60
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-download.yml
+++ b/.github/workflows/i18n-crowdin-download.yml
@@ -8,13 +8,16 @@ on:
         required: false
         default: 'main'
 
-permissions:
-  contents: write
-  pull-requests: write
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
 jobs:
   call-crowdin-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main
+    permissions:
+      contents: write      # Required for callee Crowdin download workflow to commit translation updates (when using default token paths).
+      pull-requests: write # Required for callee Crowdin PR creation flow (see reusable workflow; PAT may also be used via secrets).
     with:
       base_branch: ${{ inputs.base_branch }}
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -3,9 +3,16 @@ name: Crowdin Upload Action
 on:
   workflow_dispatch:
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   call-crowdin-upload-workflow:
     uses: newfold-labs/workflows/.github/workflows/i18n-crowdin-upload.yml@main
+    permissions:
+      contents: write      # Required for callee Crowdin upload sync that commits translation sources to the repository.
+      pull-requests: write # Required for callee Crowdin GitHub Action integration that uses GITHUB_TOKEN for PR-related updates.
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/i18n-crowdin-upload.yml
+++ b/.github/workflows/i18n-crowdin-upload.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write      # Required for callee Crowdin upload sync that commits translation sources to the repository.
       pull-requests: write # Required for callee Crowdin GitHub Action integration that uses GITHUB_TOKEN for PR-related updates.
+    timeout-minutes: 60
     with:
       CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
     secrets:

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   lint-check-spa:
     name: Run Lint Checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo for checkout and diff tooling.
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -11,20 +11,21 @@ on:
       - "src/**/*.js"
       - "src/**/*.scss"
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   lint-check-spa:
     name: Run Lint Checks
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Required to clone the repo for checkout and diff tooling.
+      contents: read        # Required for actions/checkout to clone the private repository.
+      pull-requests: read   # Required for technote-space/get-diff-action to resolve changed files via the pulls API on pull_request events.
     timeout-minutes: 30
     steps:
       - name: Checkout Repository

--- a/.github/workflows/lint-check-spa.yml
+++ b/.github/workflows/lint-check-spa.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo for checkout and diff tooling.
+    timeout-minutes: 30
     steps:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/lint-checker-php.yml
+++ b/.github/workflows/lint-checker-php.yml
@@ -1,4 +1,5 @@
-name: 'PHP Lint Check'
+name: 'Lint Checker: PHP'
+
 on:
   push:
     paths:
@@ -11,27 +12,28 @@ on:
       - '!build/**/*.php'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 # Disable permissions for all available scopes by default.
 # Any needed permissions should be configured at the job level.
 permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
     permissions:
-      contents: read # Required to clone the repo for checkout and diff tooling.
+      contents: read        # Required for actions/checkout to clone the private repository.
+      pull-requests: read   # Required for technote-space/get-diff-action to resolve changed files via the pulls API on pull_request events.
     timeout-minutes: 30
     steps:
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      # User PHP 7.4 here for compatibility with the WordPress codesniffer rules.
+      # Use PHP 7.3 for compatibility with composer.json platform and WordPress-oriented rulesets.
       - name: Setup PHP
         uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # v2.37.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,10 +15,16 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
   cancel-in-progress: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   phpcs:
     name: Run PHP Code Sniffer
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required to clone the repo for checkout and diff tooling.
     steps:
 
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read # Required to clone the repo for checkout and diff tooling.
+    timeout-minutes: 30
     steps:
 
       - name: Checkout

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -13,12 +13,17 @@ on:
         default: 'patch'
         required: true
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
 
   # This job is used to extract the branch name from the pull request or branch.
   setup:
     name: Setup
     runs-on: ubuntu-latest
+    permissions: {} # Extracts branch name from environment only; no checkout or GitHub API calls.
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -32,6 +37,9 @@ jobs:
     name: Prepare Release
     needs: setup
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
+    permissions:
+      contents: write      # Required for callee to push the release branch and version bump commits.
+      pull-requests: write # Required for callee gh pr commands and opening the release pull request.
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -24,6 +24,7 @@ jobs:
     name: Setup
     runs-on: ubuntu-latest
     permissions: {} # Extracts branch name from environment only; no checkout or GitHub API calls.
+    timeout-minutes: 5
     outputs:
       branch: ${{ steps.extract_branch.outputs.branch }}
     steps:
@@ -40,6 +41,7 @@ jobs:
     permissions:
       contents: write      # Required for callee to push the release branch and version bump commits.
       pull-requests: write # Required for callee gh pr commands and opening the release pull request.
+    timeout-minutes: 60
     with:
       module-repo: ${{ github.repository }}
       module-branch: ${{ needs.setup.outputs.branch }}

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -14,6 +14,7 @@ jobs:
     name: Send Webhook
     runs-on: ubuntu-latest
     permissions: {} # Uses secrets.WEBHOOK_TOKEN for repository-dispatch; default GITHUB_TOKEN is not used against the GitHub API.
+    timeout-minutes: 15
     steps:
 
       - name: Set Package

--- a/.github/workflows/satis-update.yml
+++ b/.github/workflows/satis-update.yml
@@ -5,10 +5,15 @@ on:
     types:
       - created
 
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
+
 jobs:
   webhook:
     name: Send Webhook
     runs-on: ubuntu-latest
+    permissions: {} # Uses secrets.WEBHOOK_TOKEN for repository-dispatch; default GITHUB_TOKEN is not used against the GitHub API.
     steps:
 
       - name: Set Package


### PR DESCRIPTION
This updates the GitHub Actions workflow files to:

- Grant minimally-scoped permissions to each job to adhere to the principle of least privilege
- Specify a timeout on each job to prevent runaway processes consuming too many minutes (the default is 360)

Once this PR is merged, [the Settings -> Actions -> Workflow permissions setting](https://github.com/WordPress/wordpress-playground/settings/actions) can be changed by a repo admin to "Read repository contents and packages permissions".

For more information, see [PRESS11-470](https://newfold.atlassian.net/browse/PRESS11-470).

## References

- https://docs.github.com/en/actions/reference/security/secure-use
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#jobsjob_idtimeout-minutes

## Use of AI

Cursor was used with (Claude Opus 4.7 and Composer 2.0 at varying points) to analyze the repository and make the initial changes.

When this PR is marked "ready for review" it means that I have manually reviewed all permissions and timeouts that were changed and made any necessary adjustments.

As a part of the analysis, the following summary was created:

## Status

| Field | Value |
|---|---|
| Workflows scanned | 9 (`auto-translate.yml`, `brand-plugin-test-playwright.yml`, `codecoverage-main.yml`, `i18n-crowdin-download.yml`, `i18n-crowdin-upload.yml`, `lint-check-spa.yml`, `lint.yml`, `newfold-prep-release.yml`, `satis-update.yml`) |
| Branch | `add/scoped-workflow-permissions` (created) |
| Permissions commit | `29a7baf7` |
| Timeouts commit | `6d82c819` |


## Top-level `permissions: {}`

| Category | Entry |
|---|---|
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `satis-update.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `lint-check-spa.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `codecoverage-main.yml` (replaced prior workflow-level `contents: read`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `brand-plugin-test-playwright.yml` (replaced prior workflow-level `contents: read`) |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `newfold-prep-release.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-upload.yml` |
| Workflows that were missing the top-level `permissions: {}` directive (added in this run): | `i18n-crowdin-download.yml` (replaced prior workflow-level grants) |
| Note: `auto-translate.yml` already had `permissions: {}`, but it was updated to include the required two-line comment block immediately above it. | — |


## Job-level `permissions:` additions

| Workflow file | Summary | Job | Permissions / notes |
|---|---|---|---|
| satis-update.yml | 1 job was missing a scoped `permissions:` directive | webhook | `permissions: {}` [3] |
| lint.yml | 1 job was missing a scoped `permissions:` directive | phpcs | `contents: read` [3] |
| lint-check-spa.yml | 1 job was missing a scoped `permissions:` directive | lint-check-spa | `contents: read` [3] |
| codecoverage-main.yml | 1 job was missing a scoped `permissions:` directive | get-repo-name | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 3 jobs were missing a compliant scoped `permissions:` directive (either missing entirely or missing required inline rationale comments) | setup | `permissions: {}` [3] |
| brand-plugin-test-playwright.yml | 3 jobs were missing a compliant scoped `permissions:` directive (either missing entirely or missing required inline rationale comments) | bluehost | `contents: read` [3] |
| brand-plugin-test-playwright.yml | 3 jobs were missing a compliant scoped `permissions:` directive (either missing entirely or missing required inline rationale comments) | bluehost-dev | `contents: read` [3] |
| newfold-prep-release.yml | 2 jobs were missing a scoped `permissions:` directive | setup | `permissions: {}` [3] |
| newfold-prep-release.yml | 2 jobs were missing a scoped `permissions:` directive | prep-release | `contents: write`, `pull-requests: write` [3] |
| i18n-crowdin-upload.yml | 1 job was missing a scoped `permissions:` directive | call-crowdin-upload-workflow | `contents: write`, `pull-requests: write` [3] |
| i18n-crowdin-download.yml | 1 job was missing explicit scoped `permissions:` at the caller job (workflow-level grants existed previously) | call-crowdin-workflow | `contents: write`, `pull-requests: write` [3] |
| auto-translate.yml | 1 job was missing per-permission inline rationale comments on an otherwise-present permissions block | translate | `contents: write`, `pull-requests: write` (documented inline) [3] |


## Permissions corrections (previously incorrect)

| # | Correction |
|---:|---|
| 1 | `codecoverage-main.yml` :: workflow-level default: BEFORE `contents: read` -> AFTER `permissions: {}` plus explicit job grants -- workflow-level read did not match the required default-deny pattern and could confuse reviewers about where token scopes are actually granted -- [3] |
| 2 | `brand-plugin-test-playwright.yml` :: workflow-level default: BEFORE `contents: read` -> AFTER `permissions: {}` plus explicit job grants -- same rationale as above -- [3] |
| 3 | `i18n-crowdin-download.yml` :: workflow vs job placement: BEFORE workflow-level `contents: write`/`pull-requests: write` -> AFTER job-level grants with inline rationale -- aligns caller workflow with default deny at workflow scope -- [3] |
| 4 | `codecoverage-main.yml` :: `codecoverage`: BEFORE undescribed `contents: write`/`pull-requests: write` -> AFTER same scopes with inline rationale tied to reusable workflow behavior (gh-pages pushes + PR comments) -- documentation/clarity correction -- [3] |


## `timeout-minutes` additions

| Workflow | Job | Minutes / action | Rationale |
|---|---|---|---|
| satis-update.yml | webhook | `15` | webhook-only job should finish quickly; caps wasted minutes if dispatch hangs. |
| lint.yml | phpcs | `30` | Composer install + PHPCS on diff scope is typically short; prevents stuck runners. |
| lint-check-spa.yml | lint-check-spa | `30` | npm install/lint steps should remain bounded on PR pushes. |
| codecoverage-main.yml | get-repo-name | `5` | single-step metadata extraction should be near-instant. |
| codecoverage-main.yml | codecoverage | `120` | reusable workflow runs a PHP version matrix plus coverage merges/publish paths that can be materially longer than typical unit-test jobs. |
| brand-plugin-test-playwright.yml | setup | `5` | branch extraction only; should never run long. |
| brand-plugin-test-playwright.yml | bluehost | `120` | reusable Playwright/wp-env style builds frequently exceed a few minutes; avoids runaway consumption on flakes/timeouts. |
| brand-plugin-test-playwright.yml | bluehost-dev | `120` | same rationale as `bluehost`. |
| newfold-prep-release.yml | setup | `5` | branch extraction only; should never run long. |
| newfold-prep-release.yml | prep-release | `60` | reusable prep-release installs dependencies, bumps versions, runs scripts, and performs git/PR operations that may take longer than lint-sized jobs. |
| i18n-crowdin-upload.yml | call-crowdin-upload-workflow | `60` | Crowdin synchronization can involve substantial upload/processing time. |
| i18n-crowdin-download.yml | call-crowdin-workflow | `60` | Crowdin download + PR-oriented workflows can take longer than trivial dispatch jobs. |
| auto-translate.yml | translate | `90` | reusable translation automation may run composer/npm tooling plus translation steps and PR preparation. |


## Notes / blockers

| # | Note |
|---:|---|
| 1 | Caller workflows cannot fully “prove” minimal scopes for reusable workflows without auditing every downstream step over time; scopes here were aligned to `newfold-labs/workflows` reusable definitions retrieved during this audit (`reusable-codecoverage.yml`, `module-plugin-test-playwright.yml`, `reusable-module-prep-release.yml`, Crowdin + translations reusables). |
| 2 | `i18n-crowdin-download.yml` calls `newfold-labs/workflows/.github/workflows/i18n-crowdin-download.yml@main`, whose reusable contract references `secrets.NEWFOLD_ACCESS_TOKEN`, while this repository workflow only passes `CROWDIN_PERSONAL_TOKEN` explicitly — verify whether `NEWFOLD_ACCESS_TOKEN` is intended to be supplied via repository/org secrets mapping (`secrets: inherit` vs explicit `secrets:`), otherwise Crowdin download PR creation may fail at runtime. |
| 3 | Local commits were created with `git -c commit.gpgsign=false` because signing failed under the automation sandbox; no `git push` was performed. |


