### PR TITLE
Fix Payments & Shipping installer slug, URL, and install path

### DIFF
--- a/includes/Data/Plugins.php
+++ b/includes/Data/Plugins.php
@@ -132,10 +132,10 @@ final class Plugins {
 			'url'      => 'https://hiive.cloud/workers/plugin-downloads/yith-stripe-payments-for-woocommerce',
 			'path'     => 'yith-stripe-payments-for-woocommerce-extended/init.php',
 		),
-		'nfd_slug_payments_shipping'                       => array(
+		'nfd_slug_wp_plugin_payments_shipping'           => array(
 			'approved' => true,
-			'url'      => 'https://hiive.cloud/workers/plugin-downloads/payments-shipping',
-			'path'     => 'payments-shipping/payments-shipping.php',
+			'url'      => 'https://hiive.cloud/workers/plugin-downloads/wp-plugin-payments-shipping',
+			'path'     => 'wp-plugin-payments-shipping/wp-plugin-payments-shipping.php',
 		),
 	);
 


### PR DESCRIPTION
https://newfold.atlassian.net/browse/PRESS0-3627

## Proposed changes

Repoints the Payments & Shipping catalog entry at the current plugin artifact. The previous `nfd_slug_payments_shipping` entry was a stale stub: its download URL 404s and its `path` (`payments-shipping/payments-shipping.php`) did not match the real built plugin.

- Renames the entry to `nfd_slug_wp_plugin_payments_shipping` (distinct from the old stub).
- Points `url` at `https://hiive.cloud/workers/plugin-downloads/wp-plugin-payments-shipping`.
- Fixes `path` to `wp-plugin-payments-shipping/wp-plugin-payments-shipping.php` (verified against the real v1.9.0 release zip).

Consumed by wp-module-ecommerce, which installs this slug on WooCommerce activation. Part of PRESS0-3627 / reported in PRESS0-4705.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Visual

N/A — data/catalog change.

## Checklist

- [x] Verified end-to-end in the Bluehost plugin wp-env: with this entry, activating WooCommerce installs + activates the plugin via the free download worker channel (validated against a real worker-served zip).
- [x] PHPCS clean (0 errors).

## Further comments

Install only succeeds once the `wp-plugin-payments-shipping` zip is published to the free download worker (Cloudflare KV `plugin-slug-url-map` key `wp-plugin-payments-shipping` → zip URL). That bucket/KV step is infra-side and tracked separately.