### PR TITLE
ci: align prep-release caller to canonical reusable-workflow format

### DIFF
--- a/.github/workflows/newfold-prep-release.yml
+++ b/.github/workflows/newfold-prep-release.yml
@@ -4,38 +4,31 @@ on:
   workflow_dispatch:
     inputs:
       level:
-        description: The level of release to be used.
+        description: 'The level of release to be used.'
         type: choice
         options:
-          - patch
-          - minor
-          - major
+          - 'patch'
+          - 'minor'
+          - 'major'
         default: 'patch'
         required: true
 
-jobs:
+# Disable permissions for all available scopes by default.
+# Any needed permissions should be configured at the job level.
+permissions: {}
 
-  # This job is used to extract the branch name from the pull request or branch.
-  setup:
-    name: Setup
-    runs-on: ubuntu-latest
-    outputs:
-      branch: ${{ steps.extract_branch.outputs.branch }}
-    steps:
-      - name: Extract branch name
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-        id: extract_branch
+jobs:
 
   # This job runs the newfold module-prep-release workflow for this module.
   prep-release:
     name: Prepare Release
-    needs: setup
+    permissions:
+      contents: write
+      pull-requests: write
     uses: newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main
     with:
       module-repo: ${{ github.repository }}
-      module-branch: ${{ needs.setup.outputs.branch }}
+      module-branch: 'main'
       level: ${{ inputs.level }}
       json-file: 'package.json'
       php-file: 'includes/Data/Constants.php'
-    secrets: inherit


### PR DESCRIPTION
## Proposed changes

The `Newfold Prepare Release` workflow has been **startup-failing** on dispatch. Its caller (`newfold-prep-release.yml`) is the stale May-2025 format — a separate `setup` job plus `secrets: inherit` and no job-level `permissions:`. Since its last successful run (Feb 2026), the shared reusable workflow (`newfold-labs/workflows/.github/workflows/reusable-module-prep-release.yml@main`) was updated; it declares **only inputs (no `secrets:`)**, so the old caller's `secrets: inherit` + missing `permissions:` now fail at workflow startup (no jobs run, no release PR created).

This repoints the caller at the **canonical format** already used by the sister modules (e.g. wp-module-ecommerce, wp-module-marketplace), which dispatch successfully:

- Drops the redundant `setup` job; hardcodes `module-branch: 'main'` (releases are always cut from main).
- Adds top-level `permissions: {}` and grants `contents: write` + `pull-requests: write` at the job level.
- Removes `secrets: inherit` (the reusable workflow declares no secrets; `GITHUB_TOKEN` is provided automatically).
- Preserves installer-specific `php-file: 'includes/Data/Constants.php'` so `NFD_INSTALLER_VERSION` is bumped.

## Type of Change

- [x] Bugfix (non-breaking change which fixes an issue)

## Further comments

CI-only change. Unblocks `Newfold Prepare Release` so it can create the automated release PR.