### PR TITLE
Fix Payments & Shipping installer URL (plugin-downloads 404 → release-api)

### DIFF
--- a/includes/Data/Plugins.php
+++ b/includes/Data/Plugins.php
@@ -134,7 +134,7 @@ final class Plugins {
 		),
 		'nfd_slug_wp_plugin_payments_shipping'           => array(
 			'approved' => true,
-			'url'      => 'https://hiive.cloud/workers/plugin-downloads/wp-plugin-payments-shipping',
+			'url'      => 'https://hiive.cloud/workers/wp-release-api/plugin/download/wp-plugin-payments-shipping/latest',
 			'path'     => 'wp-plugin-payments-shipping/wp-plugin-payments-shipping.php',
 		),
 	);


### PR DESCRIPTION
## Summary

The `nfd_slug_wp_plugin_payments_shipping` installer entry points at a URL that returns **404**, so the installer fails to download/install the plugin.

The recent fix (#530beb28) corrected the slug key and install path, but the `url` (`https://hiive.cloud/workers/plugin-downloads/wp-plugin-payments-shipping`) still 404s — the `plugin-downloads` worker does not serve this plugin under any slug.

This changes the `url` to the **release-api** download route, which actually serves the published artifact:

```
https://hiive.cloud/workers/wp-release-api/plugin/download/wp-plugin-payments-shipping/latest
```

## Verification

| URL | Result |
|-----|--------|
| `plugin-downloads/wp-plugin-payments-shipping` (current) | `404` |
| `wp-release-api/plugin/download/wp-plugin-payments-shipping/latest` (this PR) | `200`, `application/zip` |

`/latest` resolves server-side to the release flagged `is_latest = 1`, so the installer always pulls the newest published version without pinning.

## Scope

- Single-line change to `includes/Data/Plugins.php` (`url` only).
- Slug key and install path are unchanged (already correct on `main`).